### PR TITLE
Fix utils.extend

### DIFF
--- a/src/js/utils/utils.js
+++ b/src/js/utils/utils.js
@@ -23,6 +23,8 @@ LiveValidator.utils = {
                 if ( obj.hasOwnProperty( key ) && obj[ key ] !== null ) {
                     if ( obj[ key ].toString() ===  '[object Object]' ) {
                         out[ key ] = LiveValidator.utils.extend( out[ key ], obj[ key ] );
+                    } else if ( obj[ key ].constructor.name === 'Array' ) {
+                        out[ key ] = obj[ key ].slice();
                     } else {
                         out[ key ] = obj[ key ];
                     }

--- a/tests/utils/extend.js
+++ b/tests/utils/extend.js
@@ -33,4 +33,20 @@ utils.extend = function() {
         LiveValidator.utils.extend( first, second );
         expect( first ).toEqual( { 1: { '1.1': true, '1.2': false } } );
     } );
+
+    it( 'that arrays are handled as arrays', function() {
+        var initial = { array: [] };
+        var second = { array: [ 'string' ] };
+        var extend = LiveValidator.utils.extend( {}, initial, second );
+        expect( extend.array ).toEqual( [ 'string' ] );
+    } );
+
+    it( 'that arrays are not linked', function() {
+        var initial = {};
+        var added = { array: [ 'string' ] };
+        LiveValidator.utils.extend( initial, added );
+
+        // Their reference should not equal
+        expect( initial.array ).not.toBe( added.array );
+    } );
 };


### PR DESCRIPTION
Arrays used to be assigned which would cause them to share the same
reference. This leaded to some arrays (references) being changed when it
should not be happening.